### PR TITLE
gui: properly initialize the wx app

### DIFF
--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -1679,10 +1679,19 @@ Suite 330, Boston, MA  02111-1307  USA"""
         dlg.Destroy()
 
 
+class MagPyApp(wx.App):
+    # wxWindows calls this method to initialize the application
+    def OnInit(self):
+        # Create an instance of our customized Frame class
+        frame = MainFrame(None,-1,"")
+        frame.Show(True)
+        # Tell wxWindows that this is our main window
+        self.SetTopWindow(frame)
+        # Return a success flag
+        return True
+
 '''
 # To run:
-app = wx.App(redirect=False)
-frame = MainFrame(None,-1,"")
-frame.Show()
+app = MagPyApp(0)
 app.MainLoop()
 '''

--- a/magpy/gui/xmagpy
+++ b/magpy/gui/xmagpy
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
 
-from magpy.gui.magpy_gui import *
+from magpy.gui.magpy_gui import MagPyApp
 
-app = wx.App(redirect=False)
-frame = MainFrame(None,-1,"")
-frame.Show()
+app = MagPyApp(0)
 app.MainLoop()


### PR DESCRIPTION
I'm sending a pull request that you should test on windows and linux first.

The current version of xmagpy no longer works for me on OS X (it did in the past). I needed this patch to make the windows appear, otherwise I didn't get any gui at all.

The code still has some flaws though. Clicking "exit" doesn't work properly (it exits from the GUI, but the python interpreter remains open), but that's still better than not getting any GUI at all. So I need to look into that as well.

I used the following example as a guideline for creating the patch:
    https://wxpython.org/test7.py.html

The same change should be applied to the gui branch, but I wasn't able to get it working.