### PR TITLE
gui: properly initialize the wx app (gui branch)

### DIFF
--- a/magpy/gui/magpy_gui.py
+++ b/magpy/gui/magpy_gui.py
@@ -3312,10 +3312,19 @@ Suite 330, Boston, MA  02111-1307  USA"""
         # then use data_2_file method for binary writing
         pass
 
+class MagPyApp(wx.App):
+    # wxWindows calls this method to initialize the application
+    def OnInit(self):
+        # Create an instance of our customized Frame class
+        frame = MainFrame(None,-1,"")
+        frame.Show(True)
+        # Tell wxWindows that this is our main window
+        self.SetTopWindow(frame)
+        # Return a success flag
+        return True
+
 '''
 # To run:
-app = wx.App(redirect=False)
-frame = MainFrame(None,-1,"")
-frame.Show()
+app = MagPyApp(0)
 app.MainLoop()
 '''

--- a/magpy/gui/magpy_gui_test.py
+++ b/magpy/gui/magpy_gui_test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 from socket import gethostname
 
@@ -12,10 +14,7 @@ else:
 
 sys.path.insert(1,magpypath)
 
-#from magpy.stream import *
-from magpy.gui.magpy_gui import *
+from magpy.gui.magpy_gui import MagPyApp
 
-app = wx.App(redirect=False)
-frame = MainFrame(None,-1,"")
-frame.Show()
+app = MagPyApp(0)
 app.MainLoop()

--- a/magpy/gui/magpy_gui_test.py
+++ b/magpy/gui/magpy_gui_test.py
@@ -1,17 +1,10 @@
 #!/usr/bin/env python
 
+import os
 import sys
-from socket import gethostname
 
-planet = gethostname()
-leonplanets = ['Earth', 'uranus', 'saturn']
-
-
-if planet == 'zagll1':
-    magpypath = '/home/rachel/Software/MagPyDev/magpy/trunk/src/'
-else:
-    magpypath = '/home/leon/Software/magpy-git/'
-
+# run the MagPy GUI from a local source rather than from the installed version
+magpypath = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
 sys.path.insert(1,magpypath)
 
 from magpy.gui.magpy_gui import MagPyApp

--- a/magpy/gui/xmagpy
+++ b/magpy/gui/xmagpy
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
 
-from magpy.gui.magpy_gui import *
+from magpy.gui.magpy_gui import MagPyApp
 
-app = wx.App(redirect=False)
-frame = MainFrame(None,-1,"")
-frame.Show()
+app = MagPyApp(0)
 app.MainLoop()


### PR DESCRIPTION
I'm sending a pull request that you should test on windows and linux first.

The current version of `xmagpy` no longer works for me on OS X (it did in the past). I needed this patch to make the windows appear, otherwise I didn't get any gui at all.

I used the following example as a guideline for creating the patch:
https://wxpython.org/test7.py.html

The same change should be applied to the master branch, but if you plan to merge the branch soon, don't bother about master at the moment.