### PR TITLE
dialogclasses.py: us the proper length for gridSizer

### DIFF
--- a/magpy/gui/dialogclasses.py
+++ b/magpy/gui/dialogclasses.py
@@ -697,8 +697,6 @@ class StreamSelectKeysDialog(wx.Dialog):
         # A horizontal BoxSizer will contain the GridSizer (on the left)
         # and the logger text control (on the right):
         boxSizer = wx.BoxSizer(orient=wx.HORIZONTAL)
-        # A GridSizer will contain the other controls:
-        gridSizer = wx.FlexGridSizer(rows=len(self.keylst), cols=1, vgap=10, hgap=10)
 
         # Prepare some reusable arguments for calling sizer.Add():
         expandOption = dict(flag=wx.EXPAND)
@@ -709,6 +707,8 @@ class StreamSelectKeysDialog(wx.Dialog):
         contlst = [eval('(self.'+elem+'CheckBox, expandOption)') for elem in self.keylst]
         contlst.append((self.okButton, dict(flag=wx.ALIGN_CENTER)))
         contlst.append((self.closeButton, dict(flag=wx.ALIGN_CENTER)))
+        # A GridSizer will contain the other controls:
+        gridSizer = wx.FlexGridSizer(rows=len(contlst), cols=1, vgap=10, hgap=10)
         for control, options in contlst:
             gridSizer.Add(control, **options)
 


### PR DESCRIPTION
Fix for
~~~
Traceback (most recent call last):
  File "/path/to/magpy/gui/magpy_gui.py", line 2548, in onChangePlotOptions
    dlg = StreamPlotOptionsDialog(None, title='Plot Options:',optdict=self.plotopt)
  File "/path/to/magpy/gui/dialogclasses.py", line 741, in __init__
    self.doLayout()
  File "/path/to/magpy/gui/dialogclasses.py", line 772, in doLayout
    gridSizer.Add(control, **options)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/wx-3.0-osx_cocoa/wx/_core.py", line 14457, in Add
    return _core_.Sizer_Add(*args, **kwargs)
wx._core.PyAssertionError: C++ assertion "Assert failure" failed at ../src/common/sizer.cpp(1401) in DoInsert(): too many items (37 > 2*18) in grid si
~~~