### PR TITLE
Initial Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.DS_Store
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+FROM debian:jessie
+
+MAINTAINER Roman Leonhardt <roman.leonhardt@zamg.ac.at>
+LABEL geomagpy.magpy.version=0.3.2
+
+# update os
+RUN apt-get update --fix-missing && \
+    apt-get install -y --no-install-recommends \
+        bzip2 \
+        ca-certificates \
+        curl \
+        gcc \
+        gfortran \
+        libcurl4-gnutls-dev \
+        libglib2.0-0 \
+        libgnutls28-dev \
+        libncurses5 \
+        libncurses5-dev \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
+        make && \
+    apt-get clean
+
+
+# install conda
+ENV PATH /conda/bin:$PATH
+RUN echo 'export PATH=/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    curl https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh \
+        -o ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /conda && \
+    rm ~/miniconda.sh
+
+
+# install obspy and dependencies via conda
+RUN conda config --add channels obspy && \
+    conda install --yes jupyter mysql-python obspy && \
+    conda clean -i -l -t -y && \
+    useradd \
+        -c 'Docker image user' \
+        -m \
+        -r \
+        -s /sbin/nologin \
+         magpy_user && \
+    mkdir -p /home/magpy_user/notebooks && \
+    chown -R magpy_user:magpy_user /home/magpy_user
+
+
+# copy library (ignores set in .dockerignore)
+COPY . /magpy
+
+
+# install cdf, spacepy, and magpy
+RUN cd /tmp && \
+    curl -O "http://cdaweb.gsfc.nasa.gov/pub/software/cdf/dist/cdf36_2/linux/cdf36_2_1-dist-all.tar.gz" && \
+    tar -xzvf cdf36* && \
+    cd cdf36* && \
+    make OS=linux ENV=gnu CURSES=yes FORTRAN=no UCOPTIONS=-O2 SHARED=yes all && \
+    make INSTALLDIR=/usr/local/cdf install && \
+    cd /tmp && \
+    curl -O "http://netassist.dl.sourceforge.net/project/spacepy/spacepy/spacepy-0.1.6/spacepy-0.1.6.tar.gz" && \
+    tar -xzvf spacepy* && \
+    cd spacepy* && \
+    pip install . && \
+    pip install /magpy && \
+    cd /tmp && \
+    rm -rf /tmp/cdf36* /tmp/spacepy*
+
+
+USER magpy_user
+
+WORKDIR /home/magpy_user
+EXPOSE 80
+# entrypoint needs double quotes
+ENTRYPOINT [ "/magpy/docker-entrypoint.sh" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+# run jupyter in the background, and forward SIGTERM manually.
+# "exec" seems like a much simpler solution for this,
+# however, jupyter kernels die noisy deaths when using exec.
+
+_term () {
+  echo 'Caught SIGERM'
+  kill -TERM "$child"
+}
+trap _term SIGTERM
+
+
+# run jupyter notebook server
+jupyter notebook \
+    --ip='*' \
+    --notebook-dir=/home/magpy_user/notebooks \
+    --no-browser \
+    --port=8000 &
+
+child=$!
+wait "$child"


### PR DESCRIPTION
Files to automate docker container image build.

To build the docker image, run the following command from the root of the project directory (after docker is installed and configured):
```
docker build -t geomagpy/magpy:latest .
```

To run the built image, run the following command:
```
docker run -d --name magpy -p 8000:8000 geomagpy/magpy:latest
```

Then open `http://localhost:8000` in a web browser to access the jupiter notebook server.  In a new notebook, I was able to run the following python commands to verify the notebook works:
```
%matplotlib inline
from magpy.stream import read
timeseries = read('http://geomag.usgs.gov/ws/edge/?id=BOU')
timeseries.plot()
```

I also recommend setting up the docker hub ( https://hub.docker.com/ ) user/organization account "geomagpy" where you can then publish this image for other users using a command similar to:
```
docker push geomagpy/magpy:latest
```
