### PR TITLE
docs: Getting xsticks rotated

### DIFF
--- a/magpy/mpplot.py
+++ b/magpy/mpplot.py
@@ -2441,6 +2441,9 @@ def _plot(data,savedpi=80,grid=True,gridcolor=gridcolor,noshow=False,
             # --> If dates to be confined, set value types:
             _confinex(ax, tmax, tmin, timeunit)
 
+            # CONFIGURACIÓN DE LAS ETIQUETAS DEL EJE X:
+            ax.set_xticklabels(ax.get_xticklabels(), rotation=45, ha='right')
+
         if i < n_subplots-1:
             setp(ax.get_xticklabels(), visible=False)
         else:


### PR DESCRIPTION
In the function _plot, within the section where x-axis labels are configured (# SET X-LABELS), the modification ensures that x-axis labels are rotated by 45 degrees and aligned to the right for better readability. This change enhances the appearance of the plots by providing a more visually appealing and informative representation of the x-axis.

ax.set_xticklabels(ax.get_xticklabels(), rotation=45, ha='right')

This modification affects the formatting of x-axis labels in each subplot, making them more readable and improving the overall presentation of the plots.
